### PR TITLE
Fix an issue where content wasn't set

### DIFF
--- a/startup_namer/db/migrate/20120805231713_create_words.rb
+++ b/startup_namer/db/migrate/20120805231713_create_words.rb
@@ -1,7 +1,7 @@
 class CreateWords < ActiveRecord::Migration
   def change
     create_table :words do |t|
-
+      t.string :content
       t.timestamps
     end
   end


### PR DESCRIPTION
It looks like you never added the content field to the words table. You'll need to drop and rerun migrations
